### PR TITLE
Only get balance when required

### DIFF
--- a/src/main/java/me/onebone/economyapi/command/TopMoneyCommand.java
+++ b/src/main/java/me/onebone/economyapi/command/TopMoneyCommand.java
@@ -51,7 +51,7 @@ public class TopMoneyCommand extends Command {
         return possibleUuid;
     }
 
-    @Override
+	@Override
     public boolean execute(final CommandSender sender, String label, final String[] args) {
         if (!this.plugin.isEnabled()) return false;
         if (!sender.hasPermission("economyapi.command.topmoney")) {
@@ -65,12 +65,9 @@ public class TopMoneyCommand extends Command {
             final int page = args.length > 0 ? Math.max(1, Math.min(Integer.parseInt(args[0]), players.size())) : 1;
             sender.getServer().getScheduler().scheduleTask(() -> {
                 List<String> list = new LinkedList<>(money.keySet());
-
                 list.sort((s1, s2) -> Double.compare(money.get(s2), money.get(s1)));
-
                 StringBuilder output = new StringBuilder();
                 output.append(plugin.getMessage("topmoney-tag", new String[]{Integer.toString(page), Integer.toString(((players.size() + 6) / 5))}, sender)).append("\n");
-
                 if (page == 1) {
                     double total = 0;
                     for (double val : money.values()) {
@@ -78,16 +75,15 @@ public class TopMoneyCommand extends Command {
                     }
                     output.append(plugin.getMessage("topmoney-total", new String[]{EconomyAPI.MONEY_FORMAT.format(total)}, sender)).append("\n\n");
                 }
-
                 int duplicate = 0;
                 double prev = -1D;
                 for (int n = 0; n < list.size(); n++) {
-                    double m = money.get(list.get(n));
-                    if (m == prev) duplicate++;
-                    else duplicate = 0;
-                    prev = m;
                     int current = (int) Math.ceil((double) (n + 1) / 5);
                     if (page == current) {
+                    	double m = money.get(list.get(n));
+                    	if (m == prev) duplicate++;
+                    	else duplicate = 0;
+                    	prev = m;
                         output.append(plugin.getMessage("topmoney-format", new String[]{Integer.toString(n + 1 - duplicate), getName(list.get(n)), EconomyAPI.MONEY_FORMAT.format(m)}, sender)).append("\n");
                     } else if (page < current) {
                         break;


### PR DESCRIPTION
The current method causes the server to stall whilst it loops and wastes time getting money values even when they're not used.

This fix ensures the plugin only gets data from the hashmap when required.